### PR TITLE
fix broken manual channel ordering

### DIFF
--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -340,7 +340,7 @@ export default defineComponent({
 
 			moveItemInArray(netChan.network.channels, oldIndex, newIndex);
 
-			socket.emit("sort:channel", {
+			socket.emit("sort:channels", {
 				network: netChan.network.uuid,
 				order: netChan.network.channels.map((c) => c.id),
 			});


### PR DESCRIPTION
This fixes a small regression from #4861 (specifically, commit 0067c30) that resulted in manually reordering channels not being received by the server and hence not saved or synced.